### PR TITLE
Make all examples pass

### DIFF
--- a/examples/functions/no_args_multiple.code
+++ b/examples/functions/no_args_multiple.code
@@ -1,10 +1,10 @@
-def const() -> (field):
+def constant() -> (field):
   return 123123
 
 def add(field a,field b) -> (field):
-  a=const()
+  a=constant()
   return a+b
 
 def main(field a,field b) -> (field):
-  field c = add(a, b+const())
-  return const()
+  field c = add(a, b+constant())
+  return constant()

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ extern crate pest;
 extern crate pest_derive;
 
 use std::fs;
-use std::io::Read;
 
 use pest::Parser;
 
@@ -12,16 +11,19 @@ use pest::Parser;
 pub struct ZoKratesParser;
 
 fn main() {
-    // let unparsed_file = fs::read_to_string("zoksample.code").expect("cannot read file");
-    // let input_string = "for field i in 0..3 do \n c = c + a[i] \n endfor";
+    let input_string_2 = r#"def constant() -> (field):
+  return 123123
 
-    // let parse = ZoKratesParser::parse(Rule::iteration_statement, &input_string)
-    //     .expect("unsuccessful parse"); // unwrap the parse result
-    // println!("{:#?}", parse);
+def add(field a,field b) -> (field):
+  a=constant()
+  return a+b
 
-    let input_string_2 = "for field i in 0..3 do \n c = c + a[i] \n endfor \n";
+def main(field a,field b) -> (field):
+  field c = add(a, b+constant())
+  return const()
+"#;
     let parse2 =
-        ZoKratesParser::parse(Rule::statement, &input_string_2).expect("unsuccessful parse"); // unwrap the parse result
+        ZoKratesParser::parse(Rule::file, &input_string_2).map_err(|e| println!("{}", e)); // unwrap the parse result
     println!("{:#?}", parse2);
 }
 
@@ -34,6 +36,7 @@ mod tests {
         use super::*;
         extern crate glob;
         use glob::glob;
+        use std::io::Read;
 
         #[test]
         fn examples_dir() {
@@ -72,6 +75,18 @@ mod tests {
             fails_with! {
                 parser: ZoKratesParser,
                 input: "0_invalididentifier",
+                rule: Rule::identifier,
+                positives: vec![Rule::identifier],
+                negatives: vec![],
+                pos: 0
+            };
+        }
+
+        #[test]
+        fn parse_invalid_identifier_because_keyword() {
+            fails_with! {
+                parser: ZoKratesParser,
+                input: "endfor",
                 rule: Rule::identifier,
                 positives: vec![Rule::identifier],
                 negatives: vec![],

--- a/src/zokrates.pest
+++ b/src/zokrates.pest
@@ -4,12 +4,12 @@
 */
 
 // TODO: 
-// exclude language keywords as identifiers
+// exclude language keywords as identifiers: DONE
 // Ignore linebreak after \
 // Doc: associativity and precedence table for operators
 
-file = { SOI ~ import_directive* ~ program ~ EOI }
-import_directive = {"import" ~ ANY* ~ ("as" ~ identifier)? ~ NEWLINE+}
+file = { SOI ~ NEWLINE* ~ import_directive* ~ NEWLINE* ~ program ~ EOI }
+import_directive = {"import" ~ "\"" ~ (!"\"" ~ ANY)* ~ "\"" ~ ("as" ~ identifier)? ~ NEWLINE+}
 program = {function_definition+}
 function_definition = {"def" ~ identifier ~ "(" ~ parameter_list? ~ ")" ~ "->" ~ "(" ~ type_list? ~ ")" ~ ":" ~ NEWLINE* ~ statement+ }
 
@@ -31,9 +31,9 @@ statement = { (return_statement // does not require subsequent newline
 
 iteration_statement = { "for" ~ type_name ~ identifier ~ "in" ~ constant ~ ".." ~ constant ~ "do" ~ NEWLINE* ~ statement* ~ "endfor"}
 return_statement = { "return" ~ expression_list}
-multi_assignment_statement = { assignee_list ~ "=" ~ postfix_expression ~ "(" ~ expression_list? ~ ")"} // This is very specific with regards to parsing. However, I think more generality is not needed here.
+multi_assignment_statement = { assignee_list ~ "=" ~ identifier ~ "(" ~ expression_list? ~ ")"} // This is very specific with regards to parsing. However, I think more generality is not needed here.
 definition_statement = {type_name ~ identifier ~ "=" ~ expression}
-assignment_statement = {identifier ~ ("[" ~ (constant | identifier)? ~ "]")* ~ "=" ~ expression } // TODO: Is this optimal? Can the left side be written more elegantly?
+assignment_statement = {identifier ~ ("[" ~ expression ~ "]")* ~ "=" ~ expression } // TODO: Is this optimal? Can the left side be written more elegantly?
 expression_statement = {expression}
 
 assignee_list = { type_name? ~ identifier ~ ("," ~ type_name? ~ identifier)*} // declarations or assignments
@@ -48,7 +48,7 @@ and_expression = { equality_expression ~ ( "&" ~ equality_expression)* }
 equality_expression = { relational_expression ~ (("=="|"!=") ~ relational_expression)* }    
 relational_expression = { additive_expression ~ (("<"|">"|"<="|">=") ~ additive_expression)* }
 additive_expression = { multiplicative_expression ~ (("+"|"-") ~ multiplicative_expression)* }
-multiplicative_expression = { power_expression ~ (("*"|"/") ~ power_expression)* }
+multiplicative_expression = { power_expression ~ (!("//") ~ ("*"|"/") ~ power_expression)* }
 power_expression = { unary_expression ~ ("**" ~ unary_expression)* } 
 unary_expression = { "!"* ~ ( postfix_expression | conditional_expression ) }
 conditional_expression = { "if" ~ expression ~ "then" ~ expression ~ "else" ~ expression ~ "fi"}
@@ -60,17 +60,16 @@ primary_expression = { identifier
                     }
 // End Expressions
 
-// identifier = @{ !keyword ~ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")*}
-identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")*}
+identifier = @{ ((!keyword ~ ASCII_ALPHA) | (keyword ~ (ASCII_ALPHANUMERIC | "_"))) ~ (ASCII_ALPHANUMERIC | "_")* }
 constant = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
 
 WHITESPACE = _{ " " | "\t" | "\\" ~ NEWLINE}
-COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ ( !NEWLINE ~ ANY)* ~ NEWLINE) }
+COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!NEWLINE ~ ANY)*) }
 
 // TODO: Order by alphabet
-// keyword = @{"for" | "as" | "in" | "return" | "byte" | "field" |
-//             "const" | "if" | "do" | "else" | "export" | "false" |
-//             "def" | "for" | "import" | "uint" |
-//             "in" | "public" | "private" | "return" |
-//             "struct" | "true"
-//             }
+keyword = @{"for" | "endfor" | "as" | "in" | "return" | "byte" | "field" |
+            "const" | "if" | "do" | "else" | "export" | "false" |
+            "def" | "for" | "import" | "uint" |
+            "in" | "public" | "private" | "return" |
+            "struct" | "true"
+            }


### PR DESCRIPTION
Changes to the grammar:
- Allow any expression in index of array : `a[42] = 61` -> `a[42 - z + f()] = 61`
- Ban keywords, update `examples/functions/no_args_multiple.code` example to not use `const` keyword
- Pretty print in main function for debugging
- Allow newlines before imports , and between imports and program
- Restrict right side of multi_assignment to `identifier ~ (list?)` from `postfix_expression`: it has to be a function call. Should we have a `function_call` rule maybe?
- Remove conflict between division and comments on `/` (check for `!("//")`)
- Remove NEWLINE at the end of `//` comment. Not totally sure of this one!