### PR TITLE
AST friendly grammar

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,14 +59,50 @@ mod tests {
 
         #[test]
         fn parse_parameter_list() {
-            println!(
-                "{:#?}",
-                ZoKratesParser::parse(
-                    Rule::function_definition,
-                    "def foo(field a) -> (field, field): reutrn 1
-                "
-                )
-            );
+            parses_to!{
+                parser: ZoKratesParser,
+                input: "def foo(field a) -> (field, field): return 1
+                ",
+                rule: Rule::function_definition,
+                tokens: [
+                    function_definition(0, 45, [
+                        identifier(4, 7),
+                        // parameter_list is not created (silent rule)
+                        parameter(8, 15, [
+                            ty(8, 13, [
+                                ty_basic(8, 13, [
+                                    ty_field(8, 13)
+                                ])
+                            ]),
+                            identifier(14, 15)
+                        ]),
+                        // type_list is not created (silent rule)
+                        ty(21, 26, [
+                            ty_basic(21, 26, [
+                                ty_field(21, 26)
+                            ])
+                        ]),
+                        ty(28, 33, [
+                            ty_basic(28, 33, [
+                                ty_field(28, 33)
+                            ])
+                        ]),
+                        statement(36, 45, [
+                            return_statement(36, 44, [
+                                expression_list(43, 44, [
+                                    expression(43, 44, [
+                                        term(43, 44, [
+                                            primary_expression(43, 44, [
+                                                constant(43, 44)
+                                            ])
+                                        ])
+                                    ])
+                                ])
+                            ])
+                        ])
+                    ])
+                ]
+            };
         }
 
         #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod tests {
 
         #[test]
         fn parse_parameter_list() {
-            parses_to!{
+            parses_to! {
                 parser: ZoKratesParser,
                 input: "def foo(field a) -> (field, field): return 1
                 ",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,12 @@ mod tests {
 
     mod examples {
         use super::*;
-        extern crate glob;
-        use glob::glob;
-        use std::fs;
-        use std::io::Read;
 
         #[test]
         fn examples_dir() {
+            use glob::glob;
+            use std::fs;
+            use std::io::Read;
             // Traverse all .code files in examples dir
             for entry in glob("examples/**/*.code").expect("Failed to read glob pattern") {
                 match entry {
@@ -56,6 +55,12 @@ mod tests {
                     identifier(0, 18)
                 ]
             };
+        }
+
+        #[test]
+        fn parse_parameter_list() {
+            println!("{:#?}", ZoKratesParser::parse(Rule::function_definition, "def foo(field a) -> (field, field): reutrn 1
+                "));
         }
 
         #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,14 @@ mod tests {
 
         #[test]
         fn parse_parameter_list() {
-            println!("{:#?}", ZoKratesParser::parse(Rule::function_definition, "def foo(field a) -> (field, field): reutrn 1
-                "));
+            println!(
+                "{:#?}",
+                ZoKratesParser::parse(
+                    Rule::function_definition,
+                    "def foo(field a) -> (field, field): reutrn 1
+                "
+                )
+            );
         }
 
         #[test]

--- a/src/zokrates.pest
+++ b/src/zokrates.pest
@@ -41,13 +41,13 @@ statement = { (return_statement // does not require subsequent newline
 
 iteration_statement = { "for" ~ ty ~ identifier ~ "in" ~ expression ~ ".." ~ expression ~ "do" ~ NEWLINE* ~ statement* ~ "endfor"}
 return_statement = { "return" ~ expression_list}
-multi_assignment_statement = { optionally_declared_identifier_list ~ "=" ~ identifier ~ "(" ~ expression_list? ~ ")"} // This is very specific with regards to parsing. However, I think more generality is not needed here.
+multi_assignment_statement = { optionally_typed_identifier_list ~ "=" ~ identifier ~ "(" ~ expression_list? ~ ")"} // This is very specific with regards to parsing. However, I think more generality is not needed here.
 definition_statement = {ty ~ identifier ~ "=" ~ expression} // declare and assign, so only identifiers are allowed, unlike `assignment_statement`
 assignment_statement = {assignee ~ "=" ~ expression } // TODO: Is this optimal? Can the left side be written more elegantly?
 expression_statement = {expression}
 
-optionally_declared_identifier_list = _{ optionally_declared_identifier ~ ("," ~ optionally_declared_identifier)* } // declarations or assignments
-optionally_declared_identifier = { ty? ~ identifier }
+optionally_typed_identifier_list = _{ optionally_typed_identifier ~ ("," ~ optionally_typed_identifier)* } // declarations or assignments
+optionally_typed_identifier = { ty? ~ identifier }
 
 // Expressions
 expression_list = {(expression ~ ("," ~ expression)*)?}

--- a/src/zokrates.pest
+++ b/src/zokrates.pest
@@ -9,12 +9,25 @@
 // Doc: associativity and precedence table for operators
 
 file = { SOI ~ NEWLINE* ~ import_directive* ~ NEWLINE* ~ function_definition* ~ EOI }
-import_directive = {"import" ~ "\"" ~ (!"\"" ~ ANY)* ~ "\"" ~ ("as" ~ identifier)? ~ NEWLINE+}
-function_definition = {"def" ~ identifier ~ "(" ~ parameter_list? ~ ")" ~ "->" ~ "(" ~ (type_name ~ ("," ~ type_name)*)? ~ ")" ~ ":" ~ NEWLINE* ~ statement* }
+import_directive = {"import" ~ "\"" ~ import_source ~ "\"" ~ ("as" ~ identifier)? ~ NEWLINE+}
+import_source = @{(!"\"" ~ ANY)*}
+function_definition = {"def" ~ identifier ~ "(" ~ parameter_list ~ ")" ~ "->" ~ "(" ~ type_list ~ ")" ~ ":" ~ NEWLINE* ~ statement* }
 
-parameter_list = {parameter ~ ("," ~ parameter)*}
-parameter = {"private"? ~ type_name ~ identifier}
-type_name = @{"field" ~ ("[" ~ WHITESPACE* ~ expression ~ WHITESPACE* ~ "]")* | "bool" ~ ("[" ~ WHITESPACE* ~ "]")* }
+parameter_list = _{(parameter ~ ("," ~ parameter)*)?}
+parameter = {vis? ~ ty ~ identifier}
+
+// basic types
+ty_field = {"field"}
+ty_bool = {"bool"}
+ty_basic = { ty_field | ty_bool }
+// (unidimensional for now) arrays of (basic for now) types 
+ty_array = { ty_basic ~ ("[" ~ expression ~ "]") }
+ty = { ty_array | ty_basic }
+type_list = _{(ty ~ ("," ~ ty)*)?}
+
+vis_private = {"private"}
+vis_public = {"public"}
+vis = { vis_private | vis_public }
 
 // Statements 
 statement = { (return_statement // does not require subsequent newline
@@ -26,30 +39,34 @@ statement = { (return_statement // does not require subsequent newline
                 ) ~ NEWLINE 
             ) ~ NEWLINE* }
 
-iteration_statement = { "for" ~ type_name ~ identifier ~ "in" ~ constant ~ ".." ~ constant ~ "do" ~ NEWLINE* ~ statement* ~ "endfor"}
+iteration_statement = { "for" ~ ty ~ identifier ~ "in" ~ expression ~ ".." ~ expression ~ "do" ~ NEWLINE* ~ statement* ~ "endfor"}
 return_statement = { "return" ~ expression_list}
-multi_assignment_statement = { assignee_list ~ "=" ~ identifier ~ "(" ~ expression_list? ~ ")"} // This is very specific with regards to parsing. However, I think more generality is not needed here.
-definition_statement = {type_name ~ identifier ~ "=" ~ expression}
-assignment_statement = {identifier ~ ("[" ~ expression ~ "]")* ~ "=" ~ expression } // TODO: Is this optimal? Can the left side be written more elegantly?
+multi_assignment_statement = { optionally_declared_identifier_list ~ "=" ~ identifier ~ "(" ~ expression_list? ~ ")"} // This is very specific with regards to parsing. However, I think more generality is not needed here.
+definition_statement = {ty ~ identifier ~ "=" ~ expression} // declare and assign, so only identifiers are allowed, unlike `assignment_statement`
+assignment_statement = {assignee ~ "=" ~ expression } // TODO: Is this optimal? Can the left side be written more elegantly?
 expression_statement = {expression}
 
-assignee_list = { type_name? ~ identifier ~ ("," ~ type_name? ~ identifier)*} // declarations or assignments
+optionally_declared_identifier_list = _{ optionally_declared_identifier ~ ("," ~ optionally_declared_identifier)* } // declarations or assignments
+optionally_declared_identifier = { ty? ~ identifier }
 
 // Expressions
-expression_list = {expression ~ ("," ~ expression)*}
+expression_list = {(expression ~ ("," ~ expression)*)?}
 
 expression = { term ~ (op_binary ~ term)* }
 term = { ("(" ~ expression ~ ")") | conditional_expression | postfix_expression | primary_expression}
 
 conditional_expression = { "if" ~ expression ~ "then" ~ expression ~ "else" ~ expression ~ "fi"}
-postfix_expression = { primary_expression ~ ("[" ~ expression ~ "]" | "(" ~ expression_list? ~ ")")+ }
+
+postfix_expression = { identifier ~ access+ } // we force there to be at least one access, otherwise this matches single identifiers. Not sure that's what we want.
+access = {("[" ~ expression ~ "]" | "(" ~ expression_list? ~ ")")}
+
 primary_expression = { identifier
                     | constant
-                    | "(" ~ expression ~ ")"
                     | "[" ~ expression_list ~ "]" //special case for array initialization
                     }
 // End Expressions
 
+assignee = { identifier ~ ("[" ~ expression ~ "]")* }
 identifier = @{ ((!keyword ~ ASCII_ALPHA) | (keyword ~ (ASCII_ALPHANUMERIC | "_"))) ~ (ASCII_ALPHANUMERIC | "_")* }
 constant = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
 


### PR DESCRIPTION
This PR makes some changes to the grammar, mostly to make it easier to build the AST. Typically:
- define rules for concepts we want to capture in the AST (type names...)
- extract rules from complex rules to map the AST shape better and make AST deriveable

Thoughts very welcome