### PR TITLE
Make expression_list silent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,10 @@ mod tests {
                         ]),
                         statement(36, 45, [
                             return_statement(36, 44, [
-                                expression_list(43, 44, [
-                                    expression(43, 44, [
-                                        term(43, 44, [
-                                            primary_expression(43, 44, [
-                                                constant(43, 44)
-                                            ])
+                                expression(43, 44, [
+                                    term(43, 44, [
+                                        primary_expression(43, 44, [
+                                            constant(43, 44)
                                         ])
                                     ])
                                 ])

--- a/src/zokrates.pest
+++ b/src/zokrates.pest
@@ -32,7 +32,7 @@ vis = { vis_private | vis_public }
 // Statements 
 statement = { (return_statement // does not require subsequent newline
               | (iteration_statement
-                | multi_assignment_statement
+                | multi_assignment_statement // try this first as we want all assignments based on return of function calls match here and not later
                 | definition_statement
                 | assignment_statement
                 | expression_statement 
@@ -41,16 +41,16 @@ statement = { (return_statement // does not require subsequent newline
 
 iteration_statement = { "for" ~ ty ~ identifier ~ "in" ~ expression ~ ".." ~ expression ~ "do" ~ NEWLINE* ~ statement* ~ "endfor"}
 return_statement = { "return" ~ expression_list}
-multi_assignment_statement = { optionally_typed_identifier_list ~ "=" ~ identifier ~ "(" ~ expression_list? ~ ")"} // This is very specific with regards to parsing. However, I think more generality is not needed here.
+multi_assignment_statement = { optionally_typed_identifier_list ~ "=" ~ identifier ~ "(" ~ expression_list ~ ")"} // This is very specific with regards to parsing. However, I think more generality is not needed here.
 definition_statement = {ty ~ identifier ~ "=" ~ expression} // declare and assign, so only identifiers are allowed, unlike `assignment_statement`
 assignment_statement = {assignee ~ "=" ~ expression } // TODO: Is this optimal? Can the left side be written more elegantly?
 expression_statement = {expression}
 
-optionally_typed_identifier_list = _{ optionally_typed_identifier ~ ("," ~ optionally_typed_identifier)* } // declarations or assignments
+optionally_typed_identifier_list = _{ optionally_typed_identifier ~ ("," ~ optionally_typed_identifier)* }
 optionally_typed_identifier = { ty? ~ identifier }
 
 // Expressions
-expression_list = {(expression ~ ("," ~ expression)*)?}
+expression_list = _{(expression ~ ("," ~ expression)*)?}
 
 expression = { term ~ (op_binary ~ term)* }
 term = { ("(" ~ expression ~ ")") | conditional_expression | postfix_expression | primary_expression}
@@ -58,7 +58,9 @@ term = { ("(" ~ expression ~ ")") | conditional_expression | postfix_expression 
 conditional_expression = { "if" ~ expression ~ "then" ~ expression ~ "else" ~ expression ~ "fi"}
 
 postfix_expression = { identifier ~ access+ } // we force there to be at least one access, otherwise this matches single identifiers. Not sure that's what we want.
-access = {("[" ~ expression ~ "]" | "(" ~ expression_list? ~ ")")}
+access = { array_access | call_access }
+array_access = { "[" ~ expression ~ "]" }
+call_access = { "(" ~ expression_list ~ ")" }
 
 primary_expression = { identifier
                     | constant


### PR DESCRIPTION
For consistency, stop creating tokens for expression_list.

An issue this creates is that `foo[2]` and `foo(2)` both yield `[expression(2)]`, and then the AST creator cannot tell one from another.

As a consequence, define rules for accesses to remove ambiguity in the access AST creation when seeing an expression.

Then the parse tree looks like `[array_access([expression(2)])]` and `[call_access([expression(2)])]` which is fine for AST creation.
